### PR TITLE
Use javascript syntax highlighting instead of html

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installing from NPM
 How to use?
 -----------
 
-```html
+```js
 var ViralContainer = require('viraljs');
 var viralContainer = new ViralContainer();
 myExpressApp.use(viralContainer.middleware);


### PR DESCRIPTION
Seems like a typo in the readme code snippet; used html syntax highlighting for a javascript example code block.
