### PR TITLE
Change name of main entry-point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "viraljs",
   "version": "0.1.1",
   "description": "P2P distributed application made easy",
-  "main": "./src/viral-container.js",
+  "main": "./src/virus-container.js",
   "scripts": {
     "demo": "cd ./demo/ && nodemon --watch ./ --watch ../src/ ./server.js"
   },


### PR DESCRIPTION
The `main` entry point doesn't exist anymore in the current source, this will cause the following error:

```
Error: Cannot find module 'viraljs'
```

When running your app in a Babel environment.
